### PR TITLE
feat: add JWT authentication with SimpleJWT (login endpoint & settings)

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 from pathlib import Path
 from dotenv import load_dotenv
+from datetime import timedelta
 import os
 
 # BASE_DIR = backend/
@@ -48,6 +49,19 @@ INSTALLED_APPS = [
     'assets',
     'assessments',
 ]
+
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ),
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+}
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from assets.views import AssetViewSet, LocationViewSet, LoadCapacityViewSet
 from assessments.views import AssessmentViewSet
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from . import views
 
 router = DefaultRouter()
@@ -17,4 +18,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/extract/', views.extract_design_criteria, name='extract'),
     path('api/', include(router.urls)),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ djangorestframework
 psycopg2-binary
 python-dotenv
 sqlparse
+djangorestframework-simplejwt


### PR DESCRIPTION
JWT‑based authentication using djangorestframework‑simplejwt. 
Added REST framework settings, token lifetimes, and imported TokenObtainPairView/TokenRefreshView. 
Exposed /api/token/ and /api/token/refresh/ endpoints in core/urls.py. 
Updated requirements.txt and settings to enable JWT login from the React frontend. 

Refs #33 