### PR TITLE
feat(email): compliance failure alerts with Gmail/Resend provider toggle

### DIFF
--- a/Front-end package/assetguard-frontend/src/pages/Dashboard.jsx
+++ b/Front-end package/assetguard-frontend/src/pages/Dashboard.jsx
@@ -32,8 +32,8 @@ export default function Dashboard() {
     <div className="bg-gray-100 min-h-screen">
       <nav className="bg-white shadow-sm p-4 flex justify-between items-center mb-8">
         <div className="flex items-center space-x-2">
-           <div className="w-8 h-8 bg-gjp rounded-full flex items-center justify-center text-white font-bold">GJP</div>
-           <span className="font-bold text-xl">AssetGuard AI</span>
+          <div className="w-8 h-8 bg-gjp rounded-full flex items-center justify-center text-white font-bold">GJP</div>
+          <span className="font-bold text-xl">AssetGuard AI</span>
         </div>
         <button onClick={() => { localStorage.removeItem('access_token'); navigate('/'); }} className="text-red-600 font-bold">Logout</button>
       </nav>
@@ -55,7 +55,7 @@ export default function Dashboard() {
               {assets.map((asset) => (
                 <tr key={asset.id} className="border-b hover:bg-gray-50">
                   <td className="p-3 font-medium">{asset.name}</td>
-                  <td className="p-3">{asset.location}</td>
+                  <td className="p-3">{asset.location_name}</td>
                   <td className="p-3">
                     <button onClick={() => navigate(`/request/${asset.id}`)} className="bg-gjp text-white px-4 py-2 rounded">Select</button>
                   </td>

--- a/Front-end package/assetguard-frontend/src/pages/LoadEntry.jsx
+++ b/Front-end package/assetguard-frontend/src/pages/LoadEntry.jsx
@@ -1,60 +1,281 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+
+const API = 'http://localhost:8000';
 
 export default function LoadEntry() {
   const { assetId } = useParams();
   const navigate = useNavigate();
-  const [formData, setFormData] = useState({ equipment_type: 'Excavator', weight_kg: '' });
-  const [modal, setModal] = useState(null);
+
+  const [asset, setAsset] = useState(null);
+  const [equipmentOptions, setEquipmentOptions] = useState([]);
+  const [selectedEquipment, setSelectedEquipment] = useState('');
+  const [equipmentModel, setEquipmentModel] = useState('');
+  const [loadValue, setLoadValue] = useState('');
+  const [notes, setNotes] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null); // { passed: bool, details: {} }
+
+  const token = localStorage.getItem('access_token');
+
+  // Redirect if not logged in
+  useEffect(() => {
+    if (!token) navigate('/');
+  }, [token, navigate]);
+
+  // Fetch asset info + equipment options in parallel
+  useEffect(() => {
+    const headers = { Authorization: `Bearer ${token}` };
+
+    Promise.all([
+      fetch(`${API}/api/assets/${assetId}/`, { headers }).then(r => {
+        if (r.status === 401) { navigate('/'); return null; }
+        if (!r.ok) throw new Error('Asset not found');
+        return r.json();
+      }),
+      fetch(`${API}/api/equipment-options/`, { headers }).then(r => r.json()),
+    ])
+      .then(([assetData, optionsData]) => {
+        setAsset(assetData);
+        setEquipmentOptions(optionsData);
+        if (optionsData.length > 0) setSelectedEquipment(optionsData[0].value);
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [assetId, token, navigate]);
+
+  const activeOption = equipmentOptions.find(o => o.value === selectedEquipment);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const token = localStorage.getItem('access_token');
-    
+    setError('');
+    setSubmitting(true);
+
     try {
-      const response = await fetch('http://localhost:8000/api/compliance-check/', {
+      const response = await fetch(`${API}/api/assessments/`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({ asset_id: assetId, ...formData })
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          location: asset.location,
+          asset: parseInt(assetId),
+          equipment_type: selectedEquipment,
+          equipment_model: equipmentModel || null,
+          load_value: parseFloat(loadValue),
+          notes: notes || null,
+        }),
       });
-      
+
       const data = await response.json();
-      setModal({ status: data.is_compliant ? 'PASSED' : 'FAILED' });
-    } catch (error) {
-      console.error("Error:", error);
-      // 联调期间，如果后端还没写好这个接口，可以用下面这行假数据测试弹窗效果
-      // setModal({ status: 'FAILED' });
+
+      if (!response.ok) {
+        // Surface validation errors from backend
+        const msg = typeof data === 'object'
+          ? Object.values(data).flat().join(' ')
+          : 'Submission failed.';
+        setError(msg);
+        return;
+      }
+
+      setResult({
+        passed: data.is_compliant,
+        assessmentId: data.assessment_id,
+      });
+    } catch (err) {
+      setError('Network error. Is the backend running?');
+    } finally {
+      setSubmitting(false);
     }
   };
 
+  // ─── Loading state ───────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+        <div className="text-gray-500 text-lg animate-pulse">Loading asset details…</div>
+      </div>
+    );
+  }
+
+  // ─── Result modal ────────────────────────────────────────────────────────────
+  if (result) {
+    const passed = result.passed;
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+        <div className={`bg-white rounded-2xl shadow-xl max-w-sm w-full overflow-hidden`}>
+          <div className={`p-6 text-center ${passed ? 'bg-green-500' : 'bg-red-500'}`}>
+            <div className="text-5xl mb-2">{passed ? '✅' : '⚠️'}</div>
+            <h2 className="text-white text-3xl font-black tracking-wide">
+              {passed ? 'COMPLIANT' : 'NON-COMPLIANT'}
+            </h2>
+            <p className="text-white/80 mt-1 text-sm">Assessment #{result.assessmentId}</p>
+          </div>
+          <div className="p-6 text-center">
+            <p className="text-gray-600 text-sm mb-1">
+              <span className="font-semibold">{asset?.name}</span> — {asset?.location_name}
+            </p>
+            <p className="text-gray-500 text-sm">
+              {passed
+                ? 'The load is within the permitted capacity for this asset.'
+                : 'The load exceeds the permitted capacity. An alert has been sent to the responsible party.'}
+            </p>
+            <button
+              onClick={() => navigate('/dashboard')}
+              className="mt-6 w-full bg-gjp hover:bg-[#097a76] text-white font-bold py-3 rounded-xl transition-all"
+            >
+              Back to Dashboard
+            </button>
+            {!passed && (
+              <button
+                onClick={() => { setResult(null); setLoadValue(''); setNotes(''); }}
+                className="mt-2 w-full border border-gray-300 text-gray-600 font-semibold py-3 rounded-xl hover:bg-gray-50 transition-all"
+              >
+                Run Another Check
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Main form ───────────────────────────────────────────────────────────────
   return (
-    <div className="bg-gray-100 min-h-screen py-8 px-4">
-      <div className="max-w-2xl mx-auto">
-        <button onClick={() => navigate('/dashboard')} className="text-gray-600 mb-4 font-medium">← Back to Dashboard</button>
-        <div className="bg-white rounded-xl shadow-lg p-8">
-          <h2 className="text-2xl font-bold mb-6">Load Request Entry (Asset: {assetId})</h2>
-          
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="grid grid-cols-2 gap-4">
-              <input type="number" placeholder="Total Weight (kg)" required onChange={(e) => setFormData({...formData, weight_kg: e.target.value})} className="border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none" />
-              <select onChange={(e) => setFormData({...formData, equipment_type: e.target.value})} className="border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none">
-                <option value="Excavator">Excavator</option>
-                <option value="Scissor Lift">Scissor Lift</option>
-              </select>
+    <div className="min-h-screen bg-gray-100">
+      {/* Nav */}
+      <nav className="bg-white shadow-sm p-4 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <div className="w-8 h-8 bg-gjp rounded-full flex items-center justify-center text-white font-bold text-sm">GJP</div>
+          <span className="font-bold text-xl">AssetGuard AI</span>
+        </div>
+        <button
+          onClick={() => navigate('/dashboard')}
+          className="text-gray-500 hover:text-gray-800 font-medium text-sm flex items-center gap-1 transition-colors"
+        >
+          ← Back to Dashboard
+        </button>
+      </nav>
+
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        {/* Asset info header */}
+        <div className="bg-white rounded-xl shadow-sm border p-5 mb-6 flex items-start gap-4">
+          <div className="w-10 h-10 bg-gjp/10 rounded-lg flex items-center justify-center text-gjp text-xl flex-shrink-0">🏗</div>
+          <div>
+            <h1 className="text-lg font-bold text-gray-900">{asset?.name}</h1>
+            <p className="text-sm text-gray-500">📍 {asset?.location_name}</p>
+          </div>
+        </div>
+
+        {/* Form card */}
+        <div className="bg-white rounded-xl shadow-sm border p-6">
+          <h2 className="text-xl font-bold text-gray-900 mb-1">Compliance Check</h2>
+          <p className="text-sm text-gray-500 mb-6">
+            Enter the equipment load details to check against this asset's rated capacity.
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              {error}
             </div>
-            <button type="submit" className="w-full bg-gjp text-white font-bold py-4 rounded-lg">Run Compliance Check</button>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            {/* Equipment type */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                Equipment Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={selectedEquipment}
+                onChange={e => setSelectedEquipment(e.target.value)}
+                required
+                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none bg-white text-gray-900"
+              >
+                {equipmentOptions.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              {activeOption && (
+                <p className="text-xs text-gray-400 mt-1">
+                  Checks against: <span className="font-medium text-gray-600">{activeOption.capacity_name}</span>
+                </p>
+              )}
+            </div>
+
+            {/* Equipment model */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                Equipment Model <span className="text-gray-400 font-normal">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={equipmentModel}
+                onChange={e => setEquipmentModel(e.target.value)}
+                placeholder="e.g. Liebherr LTM 1100"
+                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none"
+              />
+            </div>
+
+            {/* Load value */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                {activeOption ? activeOption.load_label : 'Load Value'}
+                {activeOption && (
+                  <span className="ml-1 text-xs text-gray-400 font-normal">
+                    (checked against {activeOption.capacity_name.replace(/_/g, ' ')})
+                  </span>
+                )}
+                <span className="text-red-500"> *</span>
+              </label>
+              <div className="relative">
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={loadValue}
+                  onChange={e => setLoadValue(e.target.value)}
+                  placeholder="Enter value"
+                  required
+                  className="w-full border border-gray-300 p-3 pr-16 rounded-lg focus:ring-2 focus:ring-gjp outline-none"
+                />
+                {activeOption && (
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-medium pointer-events-none">
+                    {activeOption.load_label.toLowerCase().includes('displacement') ? 't' :
+                     activeOption.load_label.toLowerCase().includes('axle') ? 't' :
+                     activeOption.load_label.toLowerCase().includes('uniform') ? 'kPa' : 'kN'}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">
+                Notes <span className="text-gray-400 font-normal">(optional)</span>
+              </label>
+              <textarea
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                rows={3}
+                placeholder="Any additional context or observations…"
+                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none resize-none"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full bg-gjp hover:bg-[#097a76] disabled:opacity-60 text-white font-bold py-4 rounded-xl text-base transition-all"
+            >
+              {submitting ? 'Checking…' : 'Run Compliance Check'}
+            </button>
           </form>
         </div>
       </div>
-
-      {modal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
-          <div className={`bg-white rounded-xl p-8 max-w-sm w-full text-center border-t-8 ${modal.status === 'FAILED' ? 'border-red-500' : 'border-green-500'}`}>
-            <h3 className={`text-2xl font-bold ${modal.status === 'FAILED' ? 'text-red-600' : 'text-green-600'}`}>{modal.status}</h3>
-            <button onClick={() => navigate('/dashboard')} className="mt-6 w-full bg-gray-100 py-3 rounded-lg font-bold">Close & Return</button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,3 +26,11 @@ DB_PORT=5432                # 5432 = direct / 6543 = pooler
 # 5432 = direct connection
 # 6543 = Supabase pooler
 DB_PORT=5432
+
+# Gmail SMTP credentials (used when EMAIL_PROVIDER=gmail)
+EMAIL_HOST_USER=xxx@gmail.com
+EMAIL_HOST_PASSWORD=
+
+
+# Resend API (used when EMAIL_PROVIDER=resend)
+RESEND_API_KEY=

--- a/backend/assessments/views.py
+++ b/backend/assessments/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from core.permissions import IsAdmin, IsAdminOrReadOnly
+from core.email_utils import send_compliance_failure_alert
 from .models import Assessment
 from .serializers import AssessmentSerializer
 from .mappings import EQUIPMENT_CAPACITY_MAP
@@ -12,7 +13,7 @@ class AssessmentViewSet(viewsets.ModelViewSet):
         'asset', 'asset__location', 'created_by'
     ).order_by('-created_at')
     serializer_class = AssessmentSerializer
-    permission_classes = [IsAuthenticated, IsAdminOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -26,6 +27,9 @@ class AssessmentViewSet(viewsets.ModelViewSet):
                 "assessment_id": instance.id,
                 "created_by": instance.created_by.username,
             }, status=status.HTTP_201_CREATED)
+
+        # Compliance check failed — send email alert if enabled
+        send_compliance_failure_alert(request.user, instance)
 
         return Response({
             "is_compliant": False,

--- a/backend/core/email_utils.py
+++ b/backend/core/email_utils.py
@@ -1,0 +1,145 @@
+import resend as resend_sdk
+from django.conf import settings
+from django.core.mail import send_mail
+
+
+def _build_subject(assessment):
+    return f"⚠️ Compliance Check FAILED – {assessment.asset.name}"
+
+
+def _build_plain(user, assessment):
+    return f"""Compliance Check Failed
+
+Asset:          {assessment.asset.name}
+Location:       {assessment.asset.location.name}
+Equipment Type: {assessment.get_equipment_type_display()}
+Equipment Model:{assessment.equipment_model or '—'}
+Load Applied:   {assessment.load_value} {assessment.capacity_metric}
+Capacity Limit: {assessment.capacity_limit} {assessment.capacity_metric}
+Checked By:     {user.username}
+{f'Notes:          {assessment.notes}' if assessment.notes else ''}
+
+This is an automated alert from AssetGuard. Do not reply to this email.
+"""
+
+
+def _build_html(user, assessment):
+    return f"""
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #ef4444; padding: 16px 24px; border-radius: 8px 8px 0 0;">
+            <h2 style="color: white; margin: 0;">⚠️ Compliance Check Failed</h2>
+        </div>
+        <div style="background: #f9fafb; padding: 24px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px;">
+            <p style="color: #374151; font-size: 15px;">
+                Hi <strong>{user.get_full_name() or user.username}</strong>,
+            </p>
+            <p style="color: #374151; font-size: 15px;">
+                A compliance check on <strong>{assessment.asset.name}</strong> has
+                <span style="color: #ef4444; font-weight: bold;">FAILED</span>.
+                Here are the details:
+            </p>
+            <table style="width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14px;">
+                <tr style="background: #f3f4f6;">
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280; width: 40%;">Location</td>
+                    <td style="padding: 10px 14px; color: #111827;">{assessment.asset.location.name}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Asset</td>
+                    <td style="padding: 10px 14px; color: #111827;">{assessment.asset.name}</td>
+                </tr>
+                <tr style="background: #f3f4f6;">
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Equipment Type</td>
+                    <td style="padding: 10px 14px; color: #111827;">{assessment.get_equipment_type_display()}</td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Equipment Model</td>
+                    <td style="padding: 10px 14px; color: #111827;">{assessment.equipment_model or '—'}</td>
+                </tr>
+                <tr style="background: #f3f4f6;">
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Load Applied</td>
+                    <td style="padding: 10px 14px; color: #ef4444; font-weight: bold;">
+                        {assessment.load_value} {assessment.capacity_metric}
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Capacity Limit</td>
+                    <td style="padding: 10px 14px; color: #111827;">
+                        {assessment.capacity_limit} {assessment.capacity_metric}
+                    </td>
+                </tr>
+                <tr style="background: #f3f4f6;">
+                    <td style="padding: 10px 14px; font-weight: bold; color: #6b7280;">Checked By</td>
+                    <td style="padding: 10px 14px; color: #111827;">{user.username}</td>
+                </tr>
+                {"<tr><td style='padding: 10px 14px; font-weight: bold; color: #6b7280;'>Notes</td><td style='padding: 10px 14px; color: #111827;'>" + assessment.notes + "</td></tr>" if assessment.notes else ""}
+            </table>
+            <p style="color: #6b7280; font-size: 13px; margin-top: 24px; border-top: 1px solid #e5e7eb; padding-top: 16px;">
+                This is an automated alert from <strong>AssetGuard</strong>. Do not reply to this email.
+            </p>
+        </div>
+    </div>
+    """
+
+
+def _send_via_gmail(user, assessment):
+    """Send alert using Django's built-in Gmail SMTP backend."""
+    if not settings.EMAIL_HOST_USER:
+        print("[email_utils] Warning: EMAIL_HOST_USER is not set. Skipping Gmail alert.")
+        return
+
+    send_mail(
+        subject=_build_subject(assessment),
+        message=_build_plain(user, assessment),
+        from_email=f"AssetGuard Alerts <{settings.EMAIL_HOST_USER}>",
+        recipient_list=[user.email],
+        html_message=_build_html(user, assessment),
+        fail_silently=False,
+    )
+
+
+def _send_via_resend(user, assessment):
+    """Send alert using the Resend API."""
+    if not settings.RESEND_API_KEY:
+        print("[email_utils] Warning: RESEND_API_KEY is not set. Skipping Resend alert.")
+        return
+
+    resend_sdk.api_key = settings.RESEND_API_KEY
+    resend_sdk.Emails.send({
+        "from": "AssetGuard Alerts <onboarding@resend.dev>",
+        "to": [user.email],
+        "subject": _build_subject(assessment),
+        "html": _build_html(user, assessment),
+    })
+
+
+def send_compliance_failure_alert(user, assessment):
+    """
+    Send an email alert to the user when a compliance check fails.
+
+    Controlled by env vars:
+      EMAIL_ALERTS=true/false     — master on/off switch
+      EMAIL_PROVIDER=gmail/resend — which provider to use
+
+    Gmail requires: EMAIL_HOST_USER, EMAIL_HOST_PASSWORD
+    Resend requires: RESEND_API_KEY
+
+    This function is a no-op if EMAIL_ALERTS_ENABLED is False or
+    the user has no registered email address.
+    """
+    if not settings.EMAIL_ALERTS_ENABLED:
+        return
+
+    if not user.email:
+        return
+
+    provider = settings.EMAIL_PROVIDER.lower()
+
+    try:
+        if provider == 'resend':
+            _send_via_resend(user, assessment)
+        else:
+            # Default to Gmail SMTP
+            _send_via_gmail(user, assessment)
+    except Exception as e:
+        # Log but don't raise — email failure should never break the API response
+        print(f"[email_utils] Failed to send compliance alert via {provider}: {e}")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -163,6 +163,23 @@ MEDIA_ROOT = BASE_DIR / 'media'
 # CORS settings
 CORS_ALLOW_ALL_ORIGINS = True  # For development only
 
+# Email alerts — provider toggle
+# Set EMAIL_PROVIDER=gmail or EMAIL_PROVIDER=resend in .env
+EMAIL_ALERTS_ENABLED = os.getenv('EMAIL_ALERTS', 'false').lower() == 'true'
+EMAIL_PROVIDER = os.getenv('EMAIL_PROVIDER', 'gmail')  # 'gmail' or 'resend'
+
+# Gmail SMTP (used when EMAIL_PROVIDER=gmail)
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+
+# Resend API (used when EMAIL_PROVIDER=resend)
+RESEND_API_KEY = os.getenv('RESEND_API_KEY', '')
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,8 @@
-asgiref
 Django
 djangorestframework
 psycopg2-binary
 python-dotenv
-sqlparse
+django-cors-headers
+pdfplumber
 djangorestframework-simplejwt
+resend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-django
-djangorestframework
-psycopg2-binary
-python-dotenv
-resend
-django-cors-headers


### PR DESCRIPTION
- Add email_utils.py with dual-provider support (Gmail SMTP + Resend)
- Add EMAIL_PROVIDER, EMAIL_HOST_USER/PASSWORD, RESEND_API_KEY to settings
- Fix AssessmentViewSet permission: IsAdminOrReadOnly → IsAuthenticated
- Rewrite LoadEntry.jsx to use real /api/assessments/ endpoint
- Consolidate requirements: remove root requirements.txt, fix backend/requirements.txt

Ref #39 