### PR TITLE
Frontend api integration

### DIFF
--- a/Front-end package/assetguard-frontend/src/api.js
+++ b/Front-end package/assetguard-frontend/src/api.js
@@ -1,0 +1,148 @@
+// Centralized API client for AssetGuard backend.
+// - Uses JWT access token from localStorage
+// - Auto-refreshes via /api/token/refresh/ on 401 then retries the request once
+// - Throws an Error with `.status` and `.data` so callers can show backend messages
+
+export const API_BASE = 'http://127.0.0.1:8000';
+
+const ACCESS_KEY = 'access_token';
+const REFRESH_KEY = 'refresh_token';
+
+export const tokens = {
+  getAccess: () => localStorage.getItem(ACCESS_KEY),
+  getRefresh: () => localStorage.getItem(REFRESH_KEY),
+  set: (access, refresh) => {
+    if (access) localStorage.setItem(ACCESS_KEY, access);
+    if (refresh) localStorage.setItem(REFRESH_KEY, refresh);
+  },
+  clear: () => {
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+  },
+};
+
+async function refreshAccessToken() {
+  const refresh = tokens.getRefresh();
+  if (!refresh) return null;
+  const r = await fetch(`${API_BASE}/api/token/refresh/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh }),
+  });
+  if (!r.ok) return null;
+  const data = await r.json();
+  if (data.access) {
+    tokens.set(data.access, null);
+    return data.access;
+  }
+  return null;
+}
+
+// Subscribers notified when refresh fails (so the app can redirect to /login).
+const authFailureListeners = new Set();
+export function onAuthFailure(fn) {
+  authFailureListeners.add(fn);
+  return () => authFailureListeners.delete(fn);
+}
+function fireAuthFailure() {
+  tokens.clear();
+  authFailureListeners.forEach((fn) => {
+    try { fn(); } catch (_) { /* ignore */ }
+  });
+}
+
+/**
+ * Low-level request. `body` may be a plain object (auto JSON) or FormData.
+ * Set `auth: false` for unauthenticated calls (e.g. login).
+ */
+export async function request(path, { method = 'GET', body, auth = true, headers = {} } = {}) {
+  const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
+  const isForm = typeof FormData !== 'undefined' && body instanceof FormData;
+
+  const buildHeaders = () => {
+    const h = { ...headers };
+    if (body !== undefined && !isForm) h['Content-Type'] = 'application/json';
+    if (auth) {
+      const t = tokens.getAccess();
+      if (t) h['Authorization'] = `Bearer ${t}`;
+    }
+    return h;
+  };
+
+  const doFetch = () => fetch(url, {
+    method,
+    headers: buildHeaders(),
+    body: body === undefined ? undefined : (isForm ? body : JSON.stringify(body)),
+  });
+
+  let response = await doFetch();
+
+  // Try one transparent refresh on 401 for authenticated calls.
+  if (response.status === 401 && auth) {
+    const newAccess = await refreshAccessToken();
+    if (newAccess) {
+      response = await doFetch();
+    } else {
+      fireAuthFailure();
+    }
+  }
+
+  // Parse body (json if possible, else text).
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try { data = JSON.parse(text); } catch { data = text; }
+  }
+
+  if (!response.ok) {
+    const err = new Error(
+      (data && (data.detail || (typeof data === 'object' && Object.values(data).flat().join(' '))))
+      || `Request failed (${response.status})`
+    );
+    err.status = response.status;
+    err.data = data;
+    throw err;
+  }
+
+  return data;
+}
+
+// ─── High-level API helpers (mirror docs/api.md) ────────────────────────────
+
+export const api = {
+  // Auth
+  login: (username, password) =>
+    request('/api/token/', { method: 'POST', body: { username, password }, auth: false })
+      .then((d) => { tokens.set(d.access, d.refresh); return d; }),
+  logout: () => { tokens.clear(); },
+
+  // Assets
+  listAssets: (params = {}) => {
+    const qs = new URLSearchParams(params).toString();
+    return request(`/api/assets/${qs ? `?${qs}` : ''}`);
+  },
+  getAsset: (id) => request(`/api/assets/${id}/`),
+
+  // Locations
+  listLocations: () => request('/api/locations/'),
+  getLocation: (id) => request(`/api/locations/${id}/`),
+
+  // Load capacities
+  listLoadCapacities: () => request('/api/load-capacities/'),
+
+  // Equipment options
+  listEquipmentOptions: () => request('/api/equipment-options/'),
+
+  // Assessments
+  listAssessments: () => request('/api/assessments/'),
+  createAssessment: (payload) =>
+    request('/api/assessments/', { method: 'POST', body: payload }),
+
+  // PDF extract (admin)
+  extractPdf: (file, autoSave = false) => {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (autoSave) fd.append('auto_save', 'true');
+    return request('/api/extract/', { method: 'POST', body: fd });
+  },
+};

--- a/Front-end package/assetguard-frontend/src/pages/Dashboard.jsx
+++ b/Front-end package/assetguard-frontend/src/pages/Dashboard.jsx
@@ -1,31 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { api, tokens, onAuthFailure } from '../api';
 
 export default function Dashboard() {
   const [assets, setAssets] = useState([]);
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fetchAssets = async () => {
-      const token = localStorage.getItem('access_token');
-      if (!token) return navigate('/'); // 没 Token 踢回登录页
+    if (!tokens.getAccess()) { navigate('/'); return; }
+    const off = onAuthFailure(() => navigate('/'));
 
-      try {
-        const response = await fetch('http://localhost:8000/api/assets/', {
-          headers: { 'Authorization': `Bearer ${token}` }
-        });
-        if (response.ok) {
-          const data = await response.json();
-          setAssets(data);
-        } else if (response.status === 401) {
-          localStorage.removeItem('access_token');
-          navigate('/');
-        }
-      } catch (error) {
-        console.error("Fetch error:", error);
-      }
-    };
-    fetchAssets();
+    api.listAssets()
+      .then(setAssets)
+      .catch((err) => {
+        if (err.status !== 401) setError(err.message);
+      });
+
+    return off;
   }, [navigate]);
 
   return (
@@ -35,11 +27,12 @@ export default function Dashboard() {
           <div className="w-8 h-8 bg-gjp rounded-full flex items-center justify-center text-white font-bold">GJP</div>
           <span className="font-bold text-xl">AssetGuard AI</span>
         </div>
-        <button onClick={() => { localStorage.removeItem('access_token'); navigate('/'); }} className="text-red-600 font-bold">Logout</button>
+        <button onClick={() => { api.logout(); navigate('/'); }} className="text-red-600 font-bold">Logout</button>
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 py-4">
         <h1 className="text-2xl font-bold mb-6">Asset Dashboard</h1>
+        {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
         <div className="bg-white rounded-xl shadow-sm border p-6">
           <h2 className="text-lg font-bold border-b pb-2 mb-4">Select Asset for Load Request</h2>
           <table className="w-full text-left border-collapse">

--- a/Front-end package/assetguard-frontend/src/pages/LoadEntry.jsx
+++ b/Front-end package/assetguard-frontend/src/pages/LoadEntry.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-
-const API = 'http://localhost:8000';
+import { api, tokens, onAuthFailure } from '../api';
 
 export default function LoadEntry() {
-  const { assetId } = useParams();
-  const navigate = useNavigate();
+const { assetId } = useParams();
+const navigate = useNavigate();
 
   const [asset, setAsset] = useState(null);
   const [equipmentOptions, setEquipmentOptions] = useState([]);
@@ -16,35 +15,28 @@ export default function LoadEntry() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
-  const [result, setResult] = useState(null); // { passed: bool, details: {} }
+  const [result, setResult] = useState(null);
 
-  const token = localStorage.getItem('access_token');
-
-  // Redirect if not logged in
+  // Redirect if not logged in (or if a refresh fails mid-session)
   useEffect(() => {
-    if (!token) navigate('/');
-  }, [token, navigate]);
+    if (!tokens.getAccess()) { navigate('/'); return; }
+    return onAuthFailure(() => navigate('/'));
+  }, [navigate]);
 
   // Fetch asset info + equipment options in parallel
   useEffect(() => {
-    const headers = { Authorization: `Bearer ${token}` };
-
-    Promise.all([
-      fetch(`${API}/api/assets/${assetId}/`, { headers }).then(r => {
-        if (r.status === 401) { navigate('/'); return null; }
-        if (!r.ok) throw new Error('Asset not found');
-        return r.json();
-      }),
-      fetch(`${API}/api/equipment-options/`, { headers }).then(r => r.json()),
-    ])
+    let cancelled = false;
+    Promise.all([api.getAsset(assetId), api.listEquipmentOptions()])
       .then(([assetData, optionsData]) => {
+        if (cancelled) return;
         setAsset(assetData);
         setEquipmentOptions(optionsData);
         if (optionsData.length > 0) setSelectedEquipment(optionsData[0].value);
       })
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [assetId, token, navigate]);
+      .catch((err) => { if (!cancelled && err.status !== 401) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [assetId]);
 
   const activeOption = equipmentOptions.find(o => o.value === selectedEquipment);
 
@@ -52,41 +44,20 @@ export default function LoadEntry() {
     e.preventDefault();
     setError('');
     setSubmitting(true);
-
     try {
-      const response = await fetch(`${API}/api/assessments/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          location: asset.location,
-          asset: parseInt(assetId),
-          equipment_type: selectedEquipment,
-          equipment_model: equipmentModel || null,
-          load_value: parseFloat(loadValue),
-          notes: notes || null,
-        }),
-      });
+      const payload = {
+        location: asset.location,
+        asset: parseInt(assetId, 10),
+        equipment_type: selectedEquipment,
+        load_value: parseFloat(loadValue),
+      };
+      if (equipmentModel) payload.equipment_model = equipmentModel;
+      if (notes) payload.notes = notes;
 
-      const data = await response.json();
-
-      if (!response.ok) {
-        // Surface validation errors from backend
-        const msg = typeof data === 'object'
-          ? Object.values(data).flat().join(' ')
-          : 'Submission failed.';
-        setError(msg);
-        return;
-      }
-
-      setResult({
-        passed: data.is_compliant,
-        assessmentId: data.assessment_id,
-      });
+      const data = await api.createAssessment(payload);
+      setResult({ passed: data.is_compliant, assessmentId: data.assessment_id });
     } catch (err) {
-      setError('Network error. Is the backend running?');
+      setError(err.message || 'Submission failed.');
     } finally {
       setSubmitting(false);
     }

--- a/Front-end package/assetguard-frontend/src/pages/Login.jsx
+++ b/Front-end package/assetguard-frontend/src/pages/Login.jsx
@@ -1,28 +1,25 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { api } from '../api';
 
 export default function Login() {
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    setError('');
+    setSubmitting(true);
     try {
-      const response = await fetch('http://localhost:8000/api/token/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: email, password: password })
-      });
-
-      if (!response.ok) throw new Error('Invalid credentials');
-      
-      const data = await response.json();
-      localStorage.setItem('access_token', data.access); // 保存后端给的 Token
-      navigate('/dashboard'); // 登录成功跳走
+      await api.login(username, password);
+      navigate('/dashboard');
     } catch (err) {
-      setError("Login failed. Check backend connection.");
+      setError(err.message || 'Login failed. Check backend connection.');
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -35,10 +32,28 @@ export default function Login() {
         </div>
         {error && <p className="text-red-500 text-center mb-4">{error}</p>}
         <form onSubmit={handleLogin} className="space-y-6">
-          <input type="email" placeholder="Email" required onChange={(e) => setEmail(e.target.value)} className="w-full border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none" />
-          <input type="password" placeholder="Password" required onChange={(e) => setPassword(e.target.value)} className="w-full border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none" />
-          <button type="submit" className="w-full bg-gjp hover:bg-[#097a76] text-white font-bold py-3 rounded-lg transition-all">
-            Login (Contractor)
+          <input
+            type="text"
+            placeholder="Username"
+            required
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none"
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border p-3 rounded-lg focus:ring-2 focus:ring-gjp outline-none"
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-gjp hover:bg-[#097a76] disabled:opacity-60 text-white font-bold py-3 rounded-lg transition-all"
+          >
+            {submitting ? 'Signing in…' : 'Login (Contractor)'}
           </button>
         </form>
       </div>


### PR DESCRIPTION
Connects the contractor-side frontend pages to the backend API as defined in `docs/api.md`.

  ## Changes
  - **New**: `src/api.js` — centralized API client with JWT auto-refresh
  - **Login**: uses `api.login()`, stores access + refresh tokens, switched email→username field
  - **Dashboard**: uses `api.listAssets()`, subscribes to auth failure
  - **LoadEntry**: uses `api.getAsset` / `listEquipmentOptions` / `createAssessment`, omits empty optional fields, shows DRF errors

  ## Testing
  End-to-end manual test passed: login → asset list → submit compliance check (PASS at 25kN, FAIL at 60kN against a 50kN max_point_load capacity).

  ## Closes
  Closes #23
  Closes #24
  Closes #25

## Reviewer / local setup notes
  This PR only touches frontend files. To run end-to-end locally you also need:
  1. A `.env` file at the project root (gitignored) with `SECRET_KEY=...`, `USE_SQLITE=True`, `DEBUG=True`
  2. Backend running at `http://127.0.0.1:8000` (`python manage.py runserver`)
  3. At least one Location → Asset → LoadCapacity row in the DB (or via Django admin)
