### PR TITLE
Feat/mvp history log

### DIFF
--- a/backend/assessments/serializers.py
+++ b/backend/assessments/serializers.py
@@ -57,3 +57,25 @@ class AssessmentSerializer(serializers.ModelSerializer):
         data['is_compliant'] = load_value <= load_capacity.max_load
 
         return data
+
+class AssessmentHistorySerializer(serializers.ModelSerializer):
+    asset_name     = serializers.CharField(source='asset.name', read_only=True)
+    location_name  = serializers.CharField(source='asset.location.name', read_only=True)
+    load_label     = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Assessment
+        fields = [
+            'id',
+            'asset_name',
+            'location_name',
+            'load_label',       # "Max Outrigger Load"
+            'load_value',
+            'capacity_metric',  
+            'is_compliant',
+            'created_at',
+        ]
+
+    def get_load_label(self, obj):
+        mapping = EQUIPMENT_CAPACITY_MAP.get(obj.equipment_type)
+        return mapping[1] if mapping else obj.capacity_name

--- a/backend/assessments/tests.py
+++ b/backend/assessments/tests.py
@@ -1,3 +1,121 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
 
-# Create your tests here.
+from assets.models import Location, Asset, LoadCapacity
+from assessments.models import Assessment
+
+
+def get_tokens(user):
+    refresh = RefreshToken.for_user(user)
+    return str(refresh.access_token)
+
+
+def create_assessment(user, asset, location, load_value=500.0, is_compliant=True):
+    return Assessment.objects.create(
+        location=location,
+        asset=asset,
+        equipment_type="crane_with_outriggers",
+        load_value=load_value,
+        capacity_name="max_point_load",
+        capacity_metric="kN",
+        capacity_limit=1000.0,
+        is_compliant=is_compliant,
+        created_by=user,
+    )
+
+
+class AssessmentHistoryTests(APITestCase):
+    def setUp(self):
+        self.url = reverse("assessment-history-list")
+
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.other_user = User.objects.create_user(username="bob", password="pass")
+
+        self.location = Location.objects.create(name="Port of Bunbury")
+        self.asset = Asset.objects.create(name="Berth 5", location=self.location)
+        LoadCapacity.objects.create(
+            asset=self.asset,
+            name="max_point_load",
+            metric="kN",
+            max_load=1000.0,
+        )
+
+    def auth(self, user):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {get_tokens(user)}")
+
+    # --- authentication ---
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- empty history ---
+
+    def test_returns_empty_list_when_no_assessments(self):
+        self.auth(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    # --- returns own records ---
+
+    def test_returns_own_assessments(self):
+        self.auth(self.user)
+        create_assessment(self.user, self.asset, self.location)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 1)
+
+    # --- response fields ---
+
+    def test_response_fields(self):
+        self.auth(self.user)
+        create_assessment(self.user, self.asset, self.location, load_value=850.0, is_compliant=True)
+        data = self.client.get(self.url).json()[0]
+
+        self.assertIn("id", data)
+        self.assertEqual(data["asset_name"], "Berth 5")
+        self.assertEqual(data["location_name"], "Port of Bunbury")
+        self.assertEqual(data["load_label"], "Max Outrigger Load")
+        self.assertEqual(data["load_value"], 850.0)
+        self.assertEqual(data["capacity_metric"], "kN")
+        self.assertTrue(data["is_compliant"])
+        self.assertIn("created_at", data)
+
+    # --- isolation between users ---
+
+    def test_does_not_return_other_users_assessments(self):
+        self.auth(self.user)
+        create_assessment(self.other_user, self.asset, self.location)  # bob's record
+        response = self.client.get(self.url)
+        self.assertEqual(response.json(), [])
+
+    def test_only_returns_own_records_when_mixed(self):
+        create_assessment(self.user, self.asset, self.location)
+        create_assessment(self.user, self.asset, self.location)
+        create_assessment(self.other_user, self.asset, self.location)
+
+        self.auth(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(len(response.json()), 2)
+
+    # --- ordering ---
+
+    def test_ordered_most_recent_first(self):
+        a1 = create_assessment(self.user, self.asset, self.location)
+        a2 = create_assessment(self.user, self.asset, self.location)
+        # a2 was created after a1, should appear first
+        self.auth(self.user)
+        ids = [item["id"] for item in self.client.get(self.url).json()]
+        self.assertEqual(ids, [a2.id, a1.id])
+
+    # --- compliance values ---
+
+    def test_non_compliant_assessment(self):
+        self.auth(self.user)
+        create_assessment(self.user, self.asset, self.location, is_compliant=False)
+        data = self.client.get(self.url).json()[0]
+        self.assertFalse(data["is_compliant"])

--- a/backend/assessments/urls.py
+++ b/backend/assessments/urls.py
@@ -1,6 +1,5 @@
 from rest_framework.routers import DefaultRouter
-from .views import AssessmentViewSet, EquipmentOptionsViewSet
-from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet, AssessmentHistoryViewSet
+from .views import AssessmentViewSet, EquipmentOptionsViewSet, AssessmentHistoryViewSet
 
 router = DefaultRouter()
 router.register(r'assessments', AssessmentViewSet)
@@ -8,4 +7,3 @@ router.register(r'equipment-options', EquipmentOptionsViewSet, basename='equipme
 router.register(r'assessment-history', AssessmentHistoryViewSet, basename='assessment-history')
 
 urlpatterns = router.urls
-

--- a/backend/assessments/urls.py
+++ b/backend/assessments/urls.py
@@ -1,8 +1,11 @@
 from rest_framework.routers import DefaultRouter
 from .views import AssessmentViewSet, EquipmentOptionsViewSet
+from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet, AssessmentHistoryViewSet
 
 router = DefaultRouter()
 router.register(r'assessments', AssessmentViewSet)
 router.register(r'equipment-options', EquipmentOptionsViewSet, basename='equipment-options')
+router.register(r'assessment-history', AssessmentHistoryViewSet, basename='assessment-history')
 
 urlpatterns = router.urls
+

--- a/backend/assessments/views.py
+++ b/backend/assessments/views.py
@@ -54,3 +54,16 @@ class EquipmentOptionsViewSet(viewsets.ViewSet):
                 "capacity_name": capacity_name,
             })
         return Response(options)
+    
+
+class AssessmentHistoryViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = AssessmentHistorySerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Only return assessments created by the requesting user, ordered by most recent
+        return Assessment.objects.select_related(
+            'asset', 'asset__location'
+        ).filter(
+            user=self.request.user
+        ).order_by('-created_at')

--- a/backend/assessments/views.py
+++ b/backend/assessments/views.py
@@ -4,7 +4,7 @@ from rest_framework.permissions import IsAuthenticated
 from core.permissions import IsAdmin, IsAdminOrReadOnly
 from core.email_utils import send_compliance_failure_alert
 from .models import Assessment
-from .serializers import AssessmentSerializer
+from .serializers import AssessmentSerializer, AssessmentHistorySerializer
 from .mappings import EQUIPMENT_CAPACITY_MAP
 
 
@@ -65,5 +65,5 @@ class AssessmentHistoryViewSet(viewsets.ReadOnlyModelViewSet):
         return Assessment.objects.select_related(
             'asset', 'asset__location'
         ).filter(
-            user=self.request.user
+            created_by=self.request.user
         ).order_by('-created_at')

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from rest_framework.routers import DefaultRouter
 from assets.views import AssetViewSet, LocationViewSet, LoadCapacityViewSet
-from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet
+from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet, AssessmentHistoryViewSet
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from . import views
 
@@ -14,6 +14,7 @@ router.register(r'assessments', AssessmentViewSet)
 router.register(r'locations', LocationViewSet)          
 router.register(r'load-capacities', LoadCapacityViewSet)  
 router.register(r'equipment-options', EquipmentOptionsViewSet, basename='equipment-options')
+router.register(r'assessment-history', AssessmentHistoryViewSet, basename='assessment-history')
 
 urlpatterns = [
     path('', views.home, name='home'),

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -2,19 +2,17 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from rest_framework.routers import DefaultRouter
 from assets.views import AssetViewSet, LocationViewSet, LoadCapacityViewSet
-from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet, AssessmentHistoryViewSet
+from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from . import views
 
 router = DefaultRouter()
 router.register(r'assets', AssetViewSet)
 router.register(r'assessments', AssessmentViewSet)
-router.register(r'locations', LocationViewSet)          
-router.register(r'load-capacities', LoadCapacityViewSet)  
+router.register(r'locations', LocationViewSet)
+router.register(r'load-capacities', LoadCapacityViewSet)
 router.register(r'equipment-options', EquipmentOptionsViewSet, basename='equipment-options')
-router.register(r'assessment-history', AssessmentHistoryViewSet, basename='assessment-history')
 
 urlpatterns = [
     path('', views.home, name='home'),

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -2,8 +2,9 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from assets.views import AssetViewSet, LocationViewSet, LoadCapacityViewSet
 from rest_framework.routers import DefaultRouter
+from assets.views import AssetViewSet, LocationViewSet, LoadCapacityViewSet
+from assessments.views import AssessmentViewSet, EquipmentOptionsViewSet
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from . import views
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,3 +28,49 @@ Returns a list of assets.
     "notes": "Max load applies to main beam only."
   }
 ]
+
+## 7) Assessment History API
+
+### GET `/api/assessment-history/`
+
+Returns the current authenticated user's assessment history, ordered by most recent first.
+
+**Authorization**: Bearer token required
+
+**Response 200**
+
+```json
+[
+  {
+    "id": 42,
+    "asset_name": "Berth 5",
+    "location_name": "Port of Bunbury",
+    "equipment_type": "crane_with_outriggers",
+    "load_label": "Max Outrigger Load",
+    "load_value": 850.0,
+    "capacity_metric": "kN",
+    "capacity_limit": 1000.0,
+    "is_compliant": true,
+    "notes": null,
+    "created_at": "2026-04-10T08:32:00Z"
+  }
+]
+```
+
+**Response 200 (no records)**
+
+```json
+[]
+```
+
+**Response 401**
+
+```json
+{
+  "detail": "Authentication credentials were not provided."
+}
+```
+
+**Notes**
+- Only returns assessments created by the requesting user
+- Results are ordered by `created_at` descending (newest first)


### PR DESCRIPTION
Add GET /api/assessment-history/ endpoint that returns the authenticated user's past assessment records
Fix AssessmentHistoryViewSet: import missing serializer, correct filter field from user to created_by, register route in core/urls.py
Add unit tests covering authentication, field format, user isolation, ordering, and compliance values

close
#35 