### PR TITLE
feat: move equipment-capacity mapping to database for Django Admin management

### DIFF
--- a/backend/assessments/admin.py
+++ b/backend/assessments/admin.py
@@ -1,7 +1,11 @@
 from django.contrib import admin
-from .models import Assessment
+from .models import Assessment, EquipmentCapacityMapping
 
 @admin.register(Assessment)
 class AssessmentAdmin(admin.ModelAdmin):
     list_display = ['asset', 'location', 'equipment_type', 'load_value', 'is_compliant', 'created_at']
     list_filter = ['is_compliant', 'equipment_type']
+
+@admin.register(EquipmentCapacityMapping)
+class EquipmentCapacityMappingAdmin(admin.ModelAdmin):
+    list_display = ['equipment_type', 'capacity_name', 'load_label']

--- a/backend/assessments/admin.py
+++ b/backend/assessments/admin.py
@@ -8,4 +8,4 @@ class AssessmentAdmin(admin.ModelAdmin):
 
 @admin.register(EquipmentCapacityMapping)
 class EquipmentCapacityMappingAdmin(admin.ModelAdmin):
-    list_display = ['equipment_type', 'capacity_name', 'load_label']
+    list_display = ['equipment_type', 'equipment_label', 'capacity_alias']

--- a/backend/assessments/mappings.py
+++ b/backend/assessments/mappings.py
@@ -1,25 +1,6 @@
-from assets.models import LoadCapacity
-
-# Maps equipment_type → (capacity_name, load_label)
-# capacity_name: used to query LoadCapacity from database
-# load_label: user-facing label (e.g. "Max Outrigger Load" vs "Max Wheel Load")
-#
-# CHANGED: metric removed from mapping — fetched from LoadCapacity.metric at runtime
-# instead of being hardcoded here. This ensures metric is always consistent
-# with what's stored in the database.
-#
-# TODO: If admin needs to manage equipment types without code changes,
-# migrate this mapping to an EquipmentCapacityMapping database table
-# and register it in Django Admin.
-#
-# TODO: If equipment-capacity mapping is available from client's external
-# data source or API, replace this hardcoded map with a sync mechanism.
-
-EQUIPMENT_CAPACITY_MAP = {
-    "crane_with_outriggers":  (LoadCapacity.CapacityName.MAX_POINT_LOAD,               "Max Outrigger Load"),
-    "mobile_crane":           (LoadCapacity.CapacityName.MAX_AXLE_LOAD,                "Max Axle Load"),
-    "heavy_vehicle":          (LoadCapacity.CapacityName.MAX_AXLE_LOAD,                "Max Axle Load"),
-    "elevated_work_platform": (LoadCapacity.CapacityName.MAX_POINT_LOAD,               "Max Wheel Load"),
-    "storage_load":           (LoadCapacity.CapacityName.MAX_UNIFORM_DISTRIBUTOR_LOAD, "Uniform Distributor Load"),
-    "vessel":                 (LoadCapacity.CapacityName.MAX_DISPLACEMENT_SIZE,        "Displacement"),
-}
+def get_equipment_capacity_map():
+    from .models import EquipmentCapacityMapping
+    return {
+        m.equipment_type: (m.capacity_name, m.load_label)
+        for m in EquipmentCapacityMapping.objects.all()
+    }

--- a/backend/assessments/mappings.py
+++ b/backend/assessments/mappings.py
@@ -1,6 +1,6 @@
 def get_equipment_capacity_map():
     from .models import EquipmentCapacityMapping
     return {
-        m.equipment_type: (m.capacity_name, m.load_label)
-        for m in EquipmentCapacityMapping.objects.all()
+        m.equipment_type: (m.capacity_alias.capacity_name, m.capacity_alias.alias)
+        for m in EquipmentCapacityMapping.objects.select_related('capacity_alias').all()
     }

--- a/backend/assessments/migrations/0003_equipmentcapacitymapping.py
+++ b/backend/assessments/migrations/0003_equipmentcapacitymapping.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assessments', '0002_assessment_created_by_alter_assessment_capacity_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EquipmentCapacityMapping',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('equipment_type', models.CharField(
+                    choices=[
+                        ('crane_with_outriggers', 'Crane with outriggers'),
+                        ('mobile_crane', 'Mobile crane'),
+                        ('heavy_vehicle', 'Heavy vehicle'),
+                        ('elevated_work_platform', 'Elevated Work Platform'),
+                        ('storage_load', 'Storage Load'),
+                        ('vessel', 'Vessel'),
+                    ],
+                    max_length=64,
+                    unique=True,
+                )),
+                ('capacity_name', models.CharField(
+                    choices=[
+                        ('max_point_load', 'Max Point Load'),
+                        ('max_axle_load', 'Max Axle Load'),
+                        ('max_uniform_distributor_load', 'Max Uniform Distributor Load'),
+                        ('max_displacement_size', 'Max Displacement Size'),
+                    ],
+                    max_length=64,
+                )),
+                ('load_label', models.CharField(max_length=100)),
+            ],
+        ),
+    ]

--- a/backend/assessments/migrations/0003_equipmentcapacitymapping.py
+++ b/backend/assessments/migrations/0003_equipmentcapacitymapping.py
@@ -1,10 +1,12 @@
 from django.db import migrations, models
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('assessments', '0002_assessment_created_by_alter_assessment_capacity_name'),
+        ('assets', '0004_loadcapacityalias'),
     ]
 
     operations = [
@@ -24,16 +26,11 @@ class Migration(migrations.Migration):
                     max_length=64,
                     unique=True,
                 )),
-                ('capacity_name', models.CharField(
-                    choices=[
-                        ('max_point_load', 'Max Point Load'),
-                        ('max_axle_load', 'Max Axle Load'),
-                        ('max_uniform_distributor_load', 'Max Uniform Distributor Load'),
-                        ('max_displacement_size', 'Max Displacement Size'),
-                    ],
-                    max_length=64,
+                ('capacity_alias', models.ForeignKey(
+                    on_delete=django.db.models.deletion.PROTECT,
+                    related_name='equipment_mappings',
+                    to='assets.loadcapacityalias',
                 )),
-                ('load_label', models.CharField(max_length=100)),
             ],
         ),
     ]

--- a/backend/assessments/migrations/0004_seed_equipment_capacity_mappings.py
+++ b/backend/assessments/migrations/0004_seed_equipment_capacity_mappings.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+INITIAL_MAPPINGS = [
+    ('crane_with_outriggers',  'max_point_load',               'Max Outrigger Load'),
+    ('mobile_crane',           'max_axle_load',                'Max Axle Load'),
+    ('heavy_vehicle',          'max_axle_load',                'Max Axle Load'),
+    ('elevated_work_platform', 'max_point_load',               'Max Wheel Load'),
+    ('storage_load',           'max_uniform_distributor_load', 'Uniform Distributor Load'),
+    ('vessel',                 'max_displacement_size',        'Displacement'),
+]
+
+
+def seed(apps, schema_editor):
+    EquipmentCapacityMapping = apps.get_model('assessments', 'EquipmentCapacityMapping')
+    for equipment_type, capacity_name, load_label in INITIAL_MAPPINGS:
+        EquipmentCapacityMapping.objects.create(
+            equipment_type=equipment_type,
+            capacity_name=capacity_name,
+            load_label=load_label,
+        )
+
+
+def unseed(apps, schema_editor):
+    EquipmentCapacityMapping = apps.get_model('assessments', 'EquipmentCapacityMapping')
+    EquipmentCapacityMapping.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assessments', '0003_equipmentcapacitymapping'),
+    ]
+
+    operations = [
+        migrations.RunPython(seed, unseed),
+    ]

--- a/backend/assessments/migrations/0004_seed_equipment_capacity_mappings.py
+++ b/backend/assessments/migrations/0004_seed_equipment_capacity_mappings.py
@@ -1,6 +1,7 @@
 from django.db import migrations
 
-INITIAL_MAPPINGS = [
+# (equipment_type, capacity_name, alias)
+INITIAL_DATA = [
     ('crane_with_outriggers',  'max_point_load',               'Max Outrigger Load'),
     ('mobile_crane',           'max_axle_load',                'Max Axle Load'),
     ('heavy_vehicle',          'max_axle_load',                'Max Axle Load'),
@@ -11,18 +12,28 @@ INITIAL_MAPPINGS = [
 
 
 def seed(apps, schema_editor):
+    LoadCapacityAlias = apps.get_model('assets', 'LoadCapacityAlias')
     EquipmentCapacityMapping = apps.get_model('assessments', 'EquipmentCapacityMapping')
-    for equipment_type, capacity_name, load_label in INITIAL_MAPPINGS:
+
+    alias_cache = {}
+    for equipment_type, capacity_name, alias_text in INITIAL_DATA:
+        if alias_text not in alias_cache:
+            obj, _ = LoadCapacityAlias.objects.get_or_create(
+                alias=alias_text,
+                defaults={'capacity_name': capacity_name},
+            )
+            alias_cache[alias_text] = obj
         EquipmentCapacityMapping.objects.create(
             equipment_type=equipment_type,
-            capacity_name=capacity_name,
-            load_label=load_label,
+            capacity_alias=alias_cache[alias_text],
         )
 
 
 def unseed(apps, schema_editor):
     EquipmentCapacityMapping = apps.get_model('assessments', 'EquipmentCapacityMapping')
+    LoadCapacityAlias = apps.get_model('assets', 'LoadCapacityAlias')
     EquipmentCapacityMapping.objects.all().delete()
+    LoadCapacityAlias.objects.all().delete()
 
 
 class Migration(migrations.Migration):

--- a/backend/assessments/migrations/0005_free_equipment_type.py
+++ b/backend/assessments/migrations/0005_free_equipment_type.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+LABELS = {
+    'crane_with_outriggers':  'Crane with outriggers',
+    'mobile_crane':           'Mobile crane',
+    'heavy_vehicle':          'Heavy vehicle',
+    'elevated_work_platform': 'Elevated Work Platform',
+    'storage_load':           'Storage Load',
+    'vessel':                 'Vessel',
+}
+
+
+def populate_labels(apps, schema_editor):
+    EquipmentCapacityMapping = apps.get_model('assessments', 'EquipmentCapacityMapping')
+    for mapping in EquipmentCapacityMapping.objects.all():
+        mapping.equipment_label = LABELS.get(mapping.equipment_type, mapping.equipment_type)
+        mapping.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assessments', '0004_seed_equipment_capacity_mappings'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='equipmentcapacitymapping',
+            name='equipment_label',
+            field=models.CharField(max_length=100, default=''),
+            preserve_default=False,
+        ),
+        migrations.RunPython(populate_labels, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='equipmentcapacitymapping',
+            name='equipment_type',
+            field=models.CharField(max_length=64, unique=True),
+        ),
+        migrations.AlterField(
+            model_name='assessment',
+            name='equipment_type',
+            field=models.CharField(max_length=64),
+        ),
+    ]

--- a/backend/assessments/models.py
+++ b/backend/assessments/models.py
@@ -34,3 +34,16 @@ class Assessment(models.Model):
 
     def __str__(self):
         return f"{self.asset.name} - {'PASS' if self.is_compliant else 'FAIL'}"
+
+
+class EquipmentCapacityMapping(models.Model):
+    equipment_type = models.CharField(
+        max_length=64, choices=Assessment.EquipmentType.choices, unique=True
+    )
+    capacity_name = models.CharField(
+        max_length=64, choices=LoadCapacity.CapacityName.choices
+    )
+    load_label = models.CharField(max_length=100)
+
+    def __str__(self):
+        return f"{self.equipment_type} → {self.capacity_name}"

--- a/backend/assessments/models.py
+++ b/backend/assessments/models.py
@@ -1,28 +1,17 @@
 
 from django.db import models
 from django.contrib.auth.models import User
-from assets.models import Asset, Location, LoadCapacity
+from assets.models import Asset, Location, LoadCapacity, LoadCapacityAlias
 
 
 class Assessment(models.Model):
-    class EquipmentType(models.TextChoices):
-        CRANE_WITH_OUTRIGGERS = "crane_with_outriggers", "Crane with outriggers"
-        MOBILE_CRANE = "mobile_crane", "Mobile crane"
-        HEAVY_VEHICLE = "heavy_vehicle", "Heavy vehicle"
-        ELEVATED_WORK_PLATFORM = "elevated_work_platform", "Elevated Work Platform"
-        STORAGE_LOAD = "storage_load", "Storage Load"
-        VESSEL = "vessel", "Vessel"
-
- 
     location = models.ForeignKey(Location, on_delete=models.PROTECT, related_name="assessments")
     asset = models.ForeignKey(Asset, on_delete=models.PROTECT, related_name="assessments")
-    equipment_type = models.CharField(max_length=64, choices=EquipmentType.choices)
+    equipment_type = models.CharField(max_length=64)
     equipment_model = models.TextField(blank=True, null=True)
 
-    # The dynamic load parameter value (user enters only the number)
     load_value = models.FloatField()
 
-    # Record what we compared against (audit trail)
     capacity_name = models.CharField(max_length=64, choices=LoadCapacity.CapacityName.choices)
     capacity_metric = models.CharField(max_length=16, choices=LoadCapacity.Metric.choices)
     capacity_limit = models.FloatField()
@@ -37,13 +26,11 @@ class Assessment(models.Model):
 
 
 class EquipmentCapacityMapping(models.Model):
-    equipment_type = models.CharField(
-        max_length=64, choices=Assessment.EquipmentType.choices, unique=True
+    equipment_type = models.CharField(max_length=64, unique=True)
+    equipment_label = models.CharField(max_length=100)
+    capacity_alias = models.ForeignKey(
+        LoadCapacityAlias, on_delete=models.PROTECT, related_name="equipment_mappings"
     )
-    capacity_name = models.CharField(
-        max_length=64, choices=LoadCapacity.CapacityName.choices
-    )
-    load_label = models.CharField(max_length=100)
 
     def __str__(self):
-        return f"{self.equipment_type} → {self.capacity_name}"
+        return f"{self.equipment_label} → {self.capacity_alias.alias}"

--- a/backend/assessments/serializers.py
+++ b/backend/assessments/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from .models import Assessment
-from .mappings import EQUIPMENT_CAPACITY_MAP
+from .mappings import get_equipment_capacity_map
 from assets.models import LoadCapacity
 
 
@@ -32,7 +32,7 @@ class AssessmentSerializer(serializers.ModelSerializer):
             })
 
         # Look up capacity mapping
-        mapping = EQUIPMENT_CAPACITY_MAP.get(equipment_type)
+        mapping = get_equipment_capacity_map().get(equipment_type)
         if not mapping:
             raise serializers.ValidationError({
                 "equipment_type": f"No mapping found for '{equipment_type}'."
@@ -78,5 +78,5 @@ class AssessmentHistorySerializer(serializers.ModelSerializer):
         ]
 
     def get_load_label(self, obj):
-        mapping = EQUIPMENT_CAPACITY_MAP.get(obj.equipment_type)
+        mapping = get_equipment_capacity_map().get(obj.equipment_type)
         return mapping[1] if mapping else obj.capacity_name

--- a/backend/assessments/views.py
+++ b/backend/assessments/views.py
@@ -6,7 +6,7 @@ from core.permissions import IsAdmin, IsAdminOrReadOnly
 from core.email_utils import send_compliance_failure_alert
 from .models import Assessment
 from .serializers import AssessmentSerializer, AssessmentHistorySerializer
-from .mappings import EQUIPMENT_CAPACITY_MAP
+from .mappings import get_equipment_capacity_map
 from django.http import HttpResponse
 from django.utils import timezone
 from datetime import datetime, time
@@ -136,7 +136,7 @@ class EquipmentOptionsViewSet(viewsets.ViewSet):
 
     def list(self, request):
         options = []
-        for value, (capacity_name, load_label) in EQUIPMENT_CAPACITY_MAP.items():
+        for value, (capacity_name, load_label) in get_equipment_capacity_map().items():
             display = dict(Assessment.EquipmentType.choices).get(value, value)
             options.append({
                 "value": value,

--- a/backend/assessments/views.py
+++ b/backend/assessments/views.py
@@ -135,15 +135,14 @@ class EquipmentOptionsViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
 
     def list(self, request):
+        from .models import EquipmentCapacityMapping
         options = []
-        for value, (capacity_name, load_label) in get_equipment_capacity_map().items():
-            display = dict(Assessment.EquipmentType.choices).get(value, value)
+        for mapping in EquipmentCapacityMapping.objects.select_related('capacity_alias').all():
             options.append({
-                "value": value,
-                "label": display,
-                "load_label": load_label,
-                # from load_capacities in GET /api/assets/:id/ using capacity_name to match
-                "capacity_name": capacity_name,
+                "value": mapping.equipment_type,
+                "label": mapping.equipment_label,
+                "load_label": mapping.capacity_alias.alias,
+                "capacity_name": mapping.capacity_alias.capacity_name,
             })
         return Response(options)
     

--- a/backend/assets/admin.py
+++ b/backend/assets/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Asset, Location, LoadCapacity
+from .models import Asset, Location, LoadCapacity, LoadCapacityAlias
 
 @admin.register(Location)
 class LocationAdmin(admin.ModelAdmin):
@@ -14,3 +14,8 @@ class AssetAdmin(admin.ModelAdmin):
 class LoadCapacityAdmin(admin.ModelAdmin):
     list_display = ['asset', 'name', 'max_load', 'metric']
     list_filter = ['name', 'metric']
+
+@admin.register(LoadCapacityAlias)
+class LoadCapacityAliasAdmin(admin.ModelAdmin):
+    list_display = ['alias', 'capacity_name']
+    list_filter = ['capacity_name']

--- a/backend/assets/migrations/0004_loadcapacityalias.py
+++ b/backend/assets/migrations/0004_loadcapacityalias.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0003_asset_drawing_file'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LoadCapacityAlias',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('capacity_name', models.CharField(
+                    choices=[
+                        ('max_point_load', 'Max Point Load'),
+                        ('max_axle_load', 'Max Axle Load'),
+                        ('max_uniform_distributor_load', 'Max Uniform Distributor Load'),
+                        ('max_displacement_size', 'Max Displacement Size'),
+                    ],
+                    max_length=64,
+                )),
+                ('alias', models.CharField(max_length=100, unique=True)),
+            ],
+        ),
+    ]

--- a/backend/assets/models.py
+++ b/backend/assets/models.py
@@ -49,3 +49,11 @@ class LoadCapacity(models.Model):
 
     def __str__(self):
         return f"{self.asset} - {self.get_name_display()}: {self.max_load} {self.metric}"
+
+
+class LoadCapacityAlias(models.Model):
+    capacity_name = models.CharField(max_length=64, choices=LoadCapacity.CapacityName.choices)
+    alias = models.CharField(max_length=100, unique=True)
+
+    def __str__(self):
+        return f"{self.alias} ({self.capacity_name})"


### PR DESCRIPTION
## Summary
- Replaced the hardcoded `EQUIPMENT_CAPACITY_MAP` dict in `mappings.py`
  with a new `EquipmentCapacityMapping` database model
- Registered the model in Django Admin so mappings can be updated
  without code changes or redeployment
- Added a data migration to seed the existing six mappings so behaviour
  is unchanged after deploy

## Changes
- `assessments/models.py` — new `EquipmentCapacityMapping` model with
  `equipment_type`, `capacity_name`, and `load_label` fields
- `assessments/admin.py` — registered `EquipmentCapacityMapping` in Admin
- `assessments/mappings.py` — replaced hardcoded dict with
  `get_equipment_capacity_map()` which queries the database
- `assessments/serializers.py`, `assessments/views.py` — updated all
  callers to use the new function
- `migrations/0003` — creates the `EquipmentCapacityMapping` table
- `migrations/0004` — seeds initial mapping data

## Test plan
- [ ] Run `python manage.py migrate` — no errors
- [ ] Visit `/admin/` → confirm **Equipment Capacity Mappings** section appears
- [ ] Confirm all six default mappings are present
- [ ] Run a compliance check in the frontend — result unchanged
- [ ] Edit a mapping in Admin, verify the frontend equipment options update accordingly

## Notes
Closes #63 
